### PR TITLE
Fixing bugs introduced by mistake in public code

### DIFF
--- a/.github/workflows/documentation_pr.yaml
+++ b/.github/workflows/documentation_pr.yaml
@@ -13,6 +13,9 @@ jobs:
     steps:
     - name: Checkout github repo
       uses: actions/checkout@v2
+    - name: Install compilers
+      run: |
+        apt-get update -y && apt-get install -y g++ && apt-get install -y gfortran
     - name: Upgrade pip
       run: |
         pip install --upgrade pip
@@ -31,7 +34,7 @@ jobs:
     # Standard drop-in approach that should work for most people.
     - uses: ammaraskar/sphinx-action@master
       with:
-        pre-build-command: "apt-get update -y && apt-get install -y g++ && apt-get install -y gfortran && apt-get install -y pandoc"
+        pre-build-command: "apt-get install -y pandoc"
         docs-folder: "docs/"
     # Create an artifact of the html output.
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/documentation_pr.yaml
+++ b/.github/workflows/documentation_pr.yaml
@@ -13,9 +13,6 @@ jobs:
     steps:
     - name: Checkout github repo
       uses: actions/checkout@v2
-    - name: Install compilers
-      run: |
-        apt-get update -y && apt-get install -y g++ && apt-get install -y gfortran
     - name: Upgrade pip
       run: |
         pip install --upgrade pip
@@ -34,7 +31,7 @@ jobs:
     # Standard drop-in approach that should work for most people.
     - uses: ammaraskar/sphinx-action@master
       with:
-        pre-build-command: "apt-get install -y pandoc"
+        pre-build-command: "apt-get update -y && apt-get install -y g++ && apt-get install -y gfortran && apt-get install -y pandoc"
         docs-folder: "docs/"
     # Create an artifact of the html output.
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/documentation_pr.yaml
+++ b/.github/workflows/documentation_pr.yaml
@@ -13,6 +13,9 @@ jobs:
     steps:
     - name: Checkout github repo
       uses: actions/checkout@v2
+    - name: Upgrade pip
+      run: |
+        pip install --upgrade pip
     - name: Cache pip
       uses: actions/cache@v2
       with:

--- a/.github/workflows/documentation_pr.yaml
+++ b/.github/workflows/documentation_pr.yaml
@@ -31,7 +31,7 @@ jobs:
     # Standard drop-in approach that should work for most people.
     - uses: ammaraskar/sphinx-action@master
       with:
-        pre-build-command: "apt-get update -y && apt-get install -y gfortran && apt-get install -y pandoc"
+        pre-build-command: "apt-get update -y && apt-get install -y g++ && apt-get install -y gfortran && apt-get install -y pandoc"
         docs-folder: "docs/"
     # Create an artifact of the html output.
     - uses: actions/upload-artifact@v2

--- a/xfaster/xfaster_class.py
+++ b/xfaster/xfaster_class.py
@@ -1800,6 +1800,12 @@ class XFaster(object):
             if value_ref is not None:
                 for k in [field, attr]:
                     vref = value_ref.pop(k, "undef")
+                    # turn it into an array if possible to compare
+                    try:
+                        vref = pt.dict_to_arr(vref)
+                    except:
+                        pass
+
                     if not vref == "undef" and np.any(v != vref):
                         self.warn(
                             "{}: Field {} has value {}, expected {}".format(

--- a/xfaster/xfaster_class.py
+++ b/xfaster/xfaster_class.py
@@ -2023,8 +2023,8 @@ class XFaster(object):
             iteratively solving for the correction terms.
         gcorr_file : str
             If not None, path to gcorr file. Otherwise, use file labeled
-            mask_map_<tag>_gcorr.npy in mask directory for signal, or
-            mask_map_<tag>_gcorr_null.npy for nulls.
+            mask_map_<tag>_gcorr.npz in mask directory for signal, or
+            mask_map_<tag>_gcorr_null.npz for nulls.
 
         Notes
         -----
@@ -2063,7 +2063,7 @@ class XFaster(object):
             alt_name="data_xcorr",
         )
 
-        def process_gcorr(gcorr_file):
+        def process_gcorr(gcorr_file_in):
             if not hasattr(self, "gcorr"):
                 self.gcorr = None
             if apply_gcorr and self.gcorr is None:
@@ -2076,14 +2076,18 @@ class XFaster(object):
                 if not reload_gcorr and tag in self.gcorr:
                     continue
 
-                if gcorr_file is None:
+                if gcorr_file_in is None:
                     if self.null_run:
                         gcorr_file = mfile.replace(".fits", "_gcorr_null.npz")
                     else:
                         gcorr_file = mfile.replace(".fits", "_gcorr.npz")
+                else:
+                    gcorr_file = gcorr_file_in
+
                 if not os.path.exists(gcorr_file):
                     self.warn("G correction file {} not found".format(gcorr_file))
                     continue
+
                 gdata = pt.load_and_parse(gcorr_file)
                 gcorr = gdata["gcorr"]
                 for k, g in gcorr.items():

--- a/xfaster/xfaster_class.py
+++ b/xfaster/xfaster_class.py
@@ -3957,7 +3957,7 @@ class XFaster(object):
                 specs.remove("eb")
             if "tb" in specs:
                 specs.remove("tb")
-        tbeb = "eb" in specs and "tb" in specs
+        tbeb = "eb" in specs and "tb" in specs and r is None
         specs = ["cmb_{}".format(spec) for spec in specs]
 
         if not self.null_run and "fg_tt" in self.bin_def:
@@ -4063,12 +4063,16 @@ class XFaster(object):
                     cls_shape[spec] = np.append([0, 0], d[: ltmp - 2])
 
         # EB and TB flat l^2 * C_l
-        if self.pol and tbeb and (flat is None or flat is False):
-            tbeb_flat = np.abs(cls_shape["cmb_bb"][100]) * ellfac[100] * 1e-4
-            tbeb_flat = np.ones_like(cls_shape["cmb_bb"]) * tbeb_flat
-            tbeb_flat[:2] = 0
-            cls_shape["cmb_eb"] = np.copy(tbeb_flat)
-            cls_shape["cmb_tb"] = np.copy(tbeb_flat)
+        if self.pol:
+            if tbeb and (flat is None or flat is False):
+                tbeb_flat = np.abs(cls_shape["cmb_bb"][100]) * ellfac[100] * 1e-4
+                tbeb_flat = np.ones_like(cls_shape["cmb_bb"]) * tbeb_flat
+                tbeb_flat[:2] = 0
+                cls_shape["cmb_eb"] = np.copy(tbeb_flat)
+                cls_shape["cmb_tb"] = np.copy(tbeb_flat)
+            elif not tbeb:
+                cls_shape["cmb_eb"] = np.zeros_like(ell, dtype=float)
+                cls_shape["cmb_tb"] = np.zeros_like(ell, dtype=float)
 
         if "fg" in specs:
             # From Planck LIV EE dust

--- a/xfaster/xfaster_class.py
+++ b/xfaster/xfaster_class.py
@@ -6680,6 +6680,13 @@ class XFaster(object):
             If supplied, appended to the likelihood filename.
         """
 
+        # Check if OMP threads > 1. It actually slows the code way down to have
+        # more threads. Break instead.
+        assert os.getenv("OMP_NUM_THREADS") in [
+            None,
+            "1",
+        ], "OMP threads must be set to 1 for likelihood"
+
         for x in [
             r_prior,
             alpha_prior,

--- a/xfaster/xfaster_exec.py
+++ b/xfaster/xfaster_exec.py
@@ -91,7 +91,7 @@ def xfaster_run(
     reload_gcorr=False,
     gcorr_file=None,
     qb_file=None,
-    like_alpha_tags=["95", "150"],
+    like_alpha_tags=None,
     alpha_prior=[-np.inf, np.inf],
     r_prior=[-np.inf, np.inf],
     res_prior=None,
@@ -317,7 +317,8 @@ def xfaster_run(
         by the residual qb values stored in qb_file.
     like_alpha_tags : list of strings
         List of map tags from which foreground template maps should be
-        subtracted and fit in the likelihood.
+        subtracted and fit in the likelihood. If None, defaults to
+        template_alpha_tags.
     alpha_prior: list of floats
         Flat prior edges for allowed alpha values in the likelihood.
         Set to None to not fit for alpha values in the likelihood.
@@ -388,6 +389,9 @@ def xfaster_run(
             ),
             xfc.XFasterWarning,
         )
+
+    if like_alpha_tags is None:
+        like_alpha_tags = template_alpha_tags
 
     if len(template_alpha_tags) != len(template_alpha):
         raise ValueError(

--- a/xfaster/xfaster_exec.py
+++ b/xfaster/xfaster_exec.py
@@ -70,6 +70,8 @@ def xfaster_run(
     like_profiles=False,
     like_profile_sigma=3.0,
     like_profile_points=100,
+    like_r_specs=["EE", "BB"],
+    like_temp_specs=["EE", "BB", "EB"],
     pixwin=True,
     save_iters=False,
     verbose="notice",
@@ -247,6 +249,10 @@ def xfaster_run(
         Range in units of 1sigma over which to compute profile likelihoods
     like_profile_points : int
         Number of points to sample along the likelihood profile
+    like_r_specs : list
+        Which spectra to use in the r likelihood.
+    like_temp_specs : list
+        Which spectra to use for alpha in the likelihood.
     pixwin : bool
         If True, apply pixel window functions to beam windows.
     save_iters : bool
@@ -440,6 +446,7 @@ def xfaster_run(
         foreground_type_sim=foreground_type_sim,
         template_type=template_type,
         sub_planck=sub_planck,
+        sub_hm_noise=sub_hm_noise,
     )
     config_vars.update(file_opts, "File Options")
 
@@ -537,6 +544,8 @@ def xfaster_run(
         mcmc=mcmc,
         lmin=like_lmin,
         lmax=like_lmax,
+        r_specs=like_r_specs,
+        temp_specs=like_temp_specs,
         null_first_cmb=null_first_cmb,
         alpha_tags=like_alpha_tags,
         alpha_prior=alpha_prior,
@@ -550,10 +559,13 @@ def xfaster_run(
         num_walkers=mcmc_walkers,
         converge_criteria=like_converge_criteria,
         file_tag=like_tag,
+        sub_hm_noise=sub_hm_noise,
     )
     config_vars.update(like_opts, "Likelihood Estimation Options")
     config_vars.remove_option("XFaster General", "like_lmin")
     config_vars.remove_option("XFaster General", "like_lmax")
+    config_vars.remove_option("XFaster General", "like_r_specs")
+    config_vars.remove_option("XFaster General", "like_temp_specs")
     config_vars.remove_option("XFaster General", "mcmc_walkers")
     config_vars.remove_option("XFaster General", "like_converge_criteria")
     config_vars.remove_option("XFaster General", "like_tag")
@@ -612,7 +624,7 @@ def xfaster_run(
         weighted_bins=weighted_bins,
     )
 
-    if template_type is not None:
+    if template_type is not None and sub_hm_noise:
         X.log("Computing template noise ensemble averages...", "notice")
         X.get_masked_template_noise(template_type)
 
@@ -1092,6 +1104,20 @@ def xfaster_parse(args=None, test=False):
         )
         add_arg(
             G,
+            "like_r_specs",
+            nargs="+",
+            help="Which spectra to use in the r likelihood calculation",
+            choices=["TT", "EE", "BB", "TE", "EB", "TB"],
+        )
+        add_arg(
+            G,
+            "like_temp_specs",
+            nargs="+",
+            help="Which spectra to use in the alpha likelihood calculation",
+            choices=["TT", "EE", "BB", "TE", "EB", "TB"],
+        )
+        add_arg(
+            G,
             "like_profile_sigma",
             argtype=float,
             help="Range in units of 1sigma over which to compute profile likelihoods",
@@ -1432,6 +1458,8 @@ class XFasterJobGroup(object):
                     "like_beam_tags",
                     "beam_prior",
                     "res_prior",
+                    "like_r_specs",
+                    "like_temp_specs",
                     "betad_prior",
                     "dust_amp_prior",
                     "dust_ellind_prior",


### PR DESCRIPTION
This mainly fixes problems that we've accidentally introduced since making the public code:

1. gcorr being forced to be the same for all masks
2. cleaned bandpowers were always rerun regardless of checkpoint
3. EB model spectrum was changing with r in the likelihood fits, which is wrong

Other fixes:

1. Don't run get_likelihoods if more than one OMP thread is set-- doing so results in not just using up unneeded resources but also severely slowing down the MCMC code.
2. Piping through options to use different spectra in fitting r and alpha in the likelihood.
3. Use the same template alpha tags for bandpowers and likelihood by default.