### PR TITLE
Add options to improve accuracy of alm calculation

### DIFF
--- a/xfaster/xfaster_class.py
+++ b/xfaster/xfaster_class.py
@@ -162,6 +162,8 @@ class XFaster(object):
         verbose="notice",
         debug=False,
         checkpoint=None,
+        alm_pixel_weights=False,
+        alm_iter=None,
         add_log=False,
     ):
         """
@@ -187,6 +189,17 @@ class XFaster(object):
             If output data from this step forward exist on disk, they are
             are re-computed rather than loading from file.
             Options are {checkpoints}.
+        alm_pixel_weights : bool
+            If True, set the ``use_pixel_weights`` option to True when computing
+            map Alms using ``healpy.map2alm``.  If False, sets the
+            ``use_weights`` option to True instead.  Note: pixel weights ensure
+            accurate Alm computation, but can only be used for analyses where
+            ``lmax < 1.5 * nside``.
+        alm_iter : int
+            If given, set the ``iter`` option to the given value when computing
+            map Alms using ``healpy.map2alm``.  Using more iterations improves
+            the accuracy of the output Alms.  If not set, uses the default
+            number of iterations (3) as defined in healpy.
         add_log : bool
             If True, write log output to a file instead of to STDOUT.
             The log will be in ``<output_root>/run_<output_tag>.log``.
@@ -212,6 +225,16 @@ class XFaster(object):
                 )
         self.checkpoint = checkpoint
         self.force_rerun = {cp: False for cp in self.checkpoints}
+
+        # map2alm options
+        if alm_pixel_weights:
+            import healpy as hp
+
+            if hp.__version__ < "1.12.0":
+                self.warn("healpy > 1.11.0 required for alm_pixel_weights, disabling")
+                alm_pixel_weights = False
+        self.alm_pixel_weights = alm_pixel_weights
+        self.alm_iter = alm_iter
 
         if output_root is None:
             output_root = os.getcwd()
@@ -1961,9 +1984,20 @@ class XFaster(object):
         """
         import healpy as hp
 
-        if pol is None:
-            pol = self.pol
-        return np.asarray(hp.map2alm(m, self.lmax, pol=pol, use_weights=True))
+        opts = dict(pol=self.pol if pol is None else pol)
+        if self.alm_pixel_weights:
+            if self.lmax > 1.5 * self.nside:
+                raise RuntimeError(
+                    "Cannot use pixel weights for map2alm, lmax {} is > "
+                    "1.5 * nside for nside={}".format(self.lmax, self.nside)
+                )
+            opts.update(use_pixel_weights=True)
+        else:
+            opts.update(use_weights=True)
+            if self.alm_iter is not None:
+                opts.update(iter=self.alm_iter)
+
+        return np.asarray(hp.map2alm(m, self.lmax, **opts))
 
     def alm2cl(self, m1, m2=None, lmin=2, lmax=None, symmetric=True):
         """
@@ -2040,6 +2074,14 @@ class XFaster(object):
         mask_shape = self.mask_shape
         save_attrs = ["wls", "fsky", "w1", "w2", "w4", "gmat", "nside", "npix", "gcorr"]
         save_name = "masks_xcorr"
+
+        opts = {}
+        if self.alm_pixel_weights:
+            opts["alm_pixel_weights"] = self.alm_pixel_weights
+        elif self.alm_iter is not None:
+            opts["alm_iter"] = self.alm_iter
+        save_attrs += list(opts)
+
         ret = self.load_data(
             save_name,
             "masks",
@@ -2048,6 +2090,7 @@ class XFaster(object):
             to_attrs=True,
             shape=mask_shape,
             shape_ref="wls",
+            value_ref=opts or None,
         )
 
         def process_gcorr(gcorr_file_in):

--- a/xfaster/xfaster_exec.py
+++ b/xfaster/xfaster_exec.py
@@ -27,6 +27,8 @@ def xfaster_run(
     verbose="notice",
     debug=False,
     checkpoint=None,
+    alm_pixel_weights=False,
+    alm_iter=None,
     add_log=False,
     # file options
     data_root="all",
@@ -144,6 +146,18 @@ def xfaster_run(
     checkpoint : str
         If supplied, re-compute all steps of the algorithm from this point
         forward.  Valid checkpoints are {checkpoints}.
+    alm_pixel_weights : bool
+        If True, set the ``use_pixel_weights`` option to True when computing map
+        Alms using ``healpy.map2alm``.  If False, sets the ``use_weights``
+        option to True instead.  Note: pixel weights ensure accurate Alm
+        computation, but can only be used for analyses where ``lmax < 1.5 *
+        nside``.
+    alm_iter : int
+        If given, set the ``iter`` option to the given value when computing map
+        Alms using ``healpy.map2alm``.  Using more iterations improves the
+        accuracy of the output Alms.  If not set, uses the default number of
+        iterations (3) as defined in healpy.  Ignored if ``alm_pixel_weights``
+        is True.
     add_log : bool
         If True, write log output to a file instead of to STDOUT.
         The log will be in ``<output_root>/xfaster-<output_tag>.log``.
@@ -495,6 +509,8 @@ def xfaster_run(
         verbose=verbose,
         debug=debug,
         checkpoint=checkpoint,
+        alm_pixel_weights=alm_pixel_weights,
+        alm_iter=alm_iter,
         add_log=add_log,
     )
     config_vars.update(common_opts, "XFaster Common")
@@ -987,6 +1003,9 @@ def xfaster_parse(args=None, test=False):
             choices=xfc.XFaster.checkpoints,
             metavar="CHECKPOINT",
         )
+        E = G.add_mutually_exclusive_group()
+        add_arg(E, "alm_pixel_weights")
+        add_arg(E, "alm_iter", argtype=int)
 
         # file options
         G = PP.add_argument_group("file options")


### PR DESCRIPTION
By default, the map2alm calculation internal to the xfaster algorithm uses ring
weights with the default (3) iterations to compute alms.  See here for a
discussion of the accuracy of this calculation:

    https://healpix.sourceforge.io/html/fac_anafast.htm

and see here for documentation of the map2alm function:

    https://healpy.readthedocs.io/en/latest/generated/healpy.sphtfunc.map2alm.html

To improve the accuracy, we add two new options that are passed to the healpy
map2alm function:

1. alm_pixel_weights, which enables using pixel-based weights, rather than
   ring weights.  This option can only be used if lmax < 1.5 * nside.
2. alm_iter, which will default to None (i.e. keep the default number of
   iterations that healpy uses, which is 3).  Set the number of iterations to a
   higher integer value to improve the accuracy of the alms computed with ring
   weights.